### PR TITLE
Remove duplicate ReqHeroSkill

### DIFF
--- a/Events/BCOverrideRandomEvents.xml
+++ b/Events/BCOverrideRandomEvents.xml
@@ -281,7 +281,6 @@
         <ReqMoraleBelow>80</ReqMoraleBelow>
         <ReqHeroSkill>Leadership</ReqHeroSkill>
         <ReqHeroSkillLevelAbove>25</ReqHeroSkillLevelAbove>
-        <ReqHeroSkill>Leadership</ReqHeroSkill>
         <ReqHeroSkillLevelBelow>200</ReqHeroSkillLevelBelow>
     </CEEvent>
     <CEEvent>
@@ -366,7 +365,6 @@
         <ReqMoraleBelow>80</ReqMoraleBelow>
         <ReqHeroSkill>Leadership</ReqHeroSkill>
         <ReqHeroSkillLevelAbove>50</ReqHeroSkillLevelAbove>
-        <ReqHeroSkill>Leadership</ReqHeroSkill>
         <ReqHeroSkillLevelBelow>200</ReqHeroSkillLevelBelow>
     </CEEvent>
     <CEEvent>


### PR DESCRIPTION
xsd validator will complain about the duplicate element. In practice, it doesn't matter because [the logic](https://github.com/BannerlordCE/CEEvents/blob/5afbde25028b332243f5bb35fb983fc2bc9e54f4/Events/MenuCallBackDelegateRandom.cs#L888) only cares for the first ReqHeroSkill it can find.